### PR TITLE
Allow no-credential access to mongodb.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.class
+.classpath
+.project
 
 # Package Files #
 *.jar

--- a/config.bash
+++ b/config.bash
@@ -4,6 +4,8 @@
 export DB_NAME=sbtest
 
 # database username on DB_NAME
+#  Use USERNAME=none 
+#  to login to mongodb without using credentials.
 export USERNAME=myuser
 
 # database password to use for USERNAME

--- a/src/jmongosysbenchexecute.java
+++ b/src/jmongosysbenchexecute.java
@@ -1,33 +1,26 @@
 //import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoCredential;
-import com.mongodb.MongoClientOptions;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
+import com.mongodb.CommandResult;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
-import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import com.mongodb.DBCursor;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
-import com.mongodb.CommandResult;
-import com.mongodb.AggregationOutput;
 import com.mongodb.WriteResult;
-
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Properties;
-import java.util.List;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.io.Writer;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class jmongosysbenchexecute {
     public static AtomicLong globalInserts = new AtomicLong(0);
@@ -164,8 +157,16 @@ public class jmongosysbenchexecute {
 
         MongoClientOptions clientOptions = new MongoClientOptions.Builder().connectionsPerHost(2048).socketTimeout(60000).writeConcern(myWC).build();
         ServerAddress srvrAdd = new ServerAddress(serverName,serverPort);
-        MongoCredential credential = MongoCredential.createMongoCRCredential(userName, dbName, passWord.toCharArray());
-        MongoClient m = new MongoClient(srvrAdd, Arrays.asList(credential));
+        
+        // Credential login is optional.
+        MongoClient m;
+        if (userName.isEmpty() || userName.equalsIgnoreCase("none"))
+          m = new MongoClient(srvrAdd);
+        else
+        {
+          MongoCredential credential = MongoCredential.createMongoCRCredential(userName, dbName, passWord.toCharArray());
+          m = new MongoClient(srvrAdd, Arrays.asList(credential));
+        }
 
         logMe("mongoOptions | " + m.getMongoOptions().toString());
         logMe("mongoWriteConcern | " + m.getWriteConcern().toString());

--- a/src/jmongosysbenchload.java
+++ b/src/jmongosysbenchload.java
@@ -1,30 +1,22 @@
 //import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoCredential;
-import com.mongodb.MongoClientOptions;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.CommandResult;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import com.mongodb.DBCursor;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
-import com.mongodb.CommandResult;
-
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Properties;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.io.Writer;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class jmongosysbenchload {
     public static AtomicLong globalInserts = new AtomicLong(0);
@@ -116,8 +108,16 @@ public class jmongosysbenchload {
 
         MongoClientOptions clientOptions = new MongoClientOptions.Builder().connectionsPerHost(2048).socketTimeout(60000).writeConcern(myWC).build();
         ServerAddress srvrAdd = new ServerAddress(serverName,serverPort);
-        MongoCredential credential = MongoCredential.createMongoCRCredential(userName, dbName, passWord.toCharArray());
-        MongoClient m = new MongoClient(srvrAdd, Arrays.asList(credential));
+        
+        // Credential login is optional.
+        MongoClient m;
+        if (userName.isEmpty() || userName.equalsIgnoreCase("none"))
+          m = new MongoClient(srvrAdd);
+        else
+        {
+          MongoCredential credential = MongoCredential.createMongoCRCredential(userName, dbName, passWord.toCharArray());
+          m = new MongoClient(srvrAdd, Arrays.asList(credential));
+        }
 
         logMe("mongoOptions | " + m.getMongoOptions().toString());
         logMe("mongoWriteConcern | " + m.getWriteConcern().toString());


### PR DESCRIPTION
This pull request allows sysbench to access mongodb without requiring credentials.  This is accomplished by setting the USERNAME=none in config.bash and then invoking run.simple.bash in the usual way.  If executing the Java programs directly, the USERNAME can also be the empty string.  In addition, unused imports are deleted.